### PR TITLE
SL-5434 Update nexus-staging-maven-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.8</version>
+            <version>1.6.13</version>
             <extensions>true</extensions>
             <configuration>
               <serverId>ossrh</serverId>


### PR DESCRIPTION
### Description of Changes

Version of `nexus-staging-maven-plugin` updated to 1.6.13 as per [this StackOverflow solution](https://stackoverflow.com/questions/70153962/nexus-staging-maven-plugin-maven-deploy-failed-an-api-incompatibility-was-enco#:~:text=Updating%20nexus%2Dstaging%2Dmaven%2Dplugin%20to%201.6.13%20will%20solve%20your%20problem)

### Documentation

N/A

### Risks & Impacts

None

### Testing

This version is in use on the tiktok-sdk

## Final Checklist

Please tick once completed.

- [ ] Build passes.
- [ ] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [ ] Change log has been updated.