### PR TITLE
Release v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ebx-cachebase-sdk Changelog
 
+## 1.4.1 (Jan 9, 2024)
+
+* Bump lettuce-core dependency to `6.3.0.RELEASE` for redis 7 support
+
 ## 1.4.0 (Mar 30, 2023)
 
 * Ensure that the Redis cluster topology is always refreshed and allow the period to be configured

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>com.echobox</groupId>
   <artifactId>ebx-cachebase-sdk</artifactId>
-  <version>1.4.0</version>
+  <version>1.4.1</version>
   <packaging>jar</packaging>
 
   <properties>
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>io.lettuce</groupId>
       <artifactId>lettuce-core</artifactId>
-      <version>6.1.8.RELEASE</version>
+      <version>6.3.0.RELEASE</version>
     </dependency>
     <!-- commons-pool2 required by lettuce for connection pooling -->
     <dependency>


### PR DESCRIPTION
### Description of Changes

Upgrade lettuce-core dependency to latest version `6.3.0.RELEASE` for redis 7 support.

Update Changelog

Bump pom version (patch)

#25 