### PR TITLE
NL-8893 Add support for retrieving cached items with their time to live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ebx-cachebase-sdk Changelog
 
+## 2.0.0 (Oct 17, 2024)
+* Added support for retrieving items from the cache with their time to live atomically
+* This involved adding a new abstract method `getRawCachedItemWithTtl` to `CacheService`
+* Note that attempting to retrieve items from the cache with their time to live will always 
+  throw an `UnsupportedOperationException` for the `MemcachedCacheService`
+
 ## 1.4.1 (Jan 9, 2024)
 
 * Bump lettuce-core dependency to `6.3.0.RELEASE` for redis 7 support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # ebx-cachebase-sdk Changelog
 
-## 2.0.0 (Oct 17, 2024)
+## 2.0.0 (Oct 18, 2024)
 * Added support for retrieving items from the cache with their time to live atomically
 * This involved adding a new abstract method `getRawCachedItemWithTtl` to `CacheService`
 * Note that attempting to retrieve items from the cache with their time to live will always 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For our latest stable release use:
 <dependency>
   <groupId>com.echobox</groupId>
   <artifactId>ebx-cachebase-sdk</artifactId>
-  <version>2.0.0</version>
+  <version>1.4.0</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For our latest stable release use:
 <dependency>
   <groupId>com.echobox</groupId>
   <artifactId>ebx-cachebase-sdk</artifactId>
-  <version>1.4.0</version>
+  <version>2.0.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>com.echobox</groupId>
   <artifactId>ebx-cachebase-sdk</artifactId>
-  <version>1.4.1</version>
+  <version>2.0.0</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/src/main/java/com/echobox/cache/CacheService.java
+++ b/src/main/java/com/echobox/cache/CacheService.java
@@ -375,8 +375,7 @@ public abstract class CacheService {
    */
   @SuppressWarnings("unchecked")
   public <T, E extends Exception> Optional<CachedResult<T>> tryGetCachedItemWithTtl(String key,
-      TypeToken<T> typeToken,
-      Set<Class<? extends E>> exceptionsToThrowDirectly) throws E {
+      TypeToken<T> typeToken, Set<Class<? extends E>> exceptionsToThrowDirectly) throws E {
     validateInputs(key, typeToken, exceptionsToThrowDirectly);
     
     // Check to see if we might be able to access a cached item

--- a/src/main/java/com/echobox/cache/CachedResult.java
+++ b/src/main/java/com/echobox/cache/CachedResult.java
@@ -24,9 +24,9 @@ package com.echobox.cache;
  */
 public class CachedResult<T> {
   private final T value;
-  private final Long ttl;
+  private final long ttl;
   
-  public CachedResult(T value, Long ttl) {
+  public CachedResult(T value, long ttl) {
     this.value = value;
     this.ttl = ttl;
   }
@@ -35,7 +35,7 @@ public class CachedResult<T> {
     return value;
   }
   
-  public Long getTtl() {
+  public long getTtl() {
     return ttl;
   }
 }

--- a/src/main/java/com/echobox/cache/CachedResult.java
+++ b/src/main/java/com/echobox/cache/CachedResult.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.cache;
+
+/**
+ * Represents the result of retrieving from the cache
+ * @param <T> - the type of the value
+ * @author KHassan98
+ */
+public class CachedResult<T> {
+  private final T value;
+  private final Long ttl;
+  
+  public CachedResult(T value, Long ttl) {
+    this.value = value;
+    this.ttl = ttl;
+  }
+  
+  public T getValue() {
+    return value;
+  }
+  
+  public Long getTtl() {
+    return ttl;
+  }
+}

--- a/src/main/java/com/echobox/cache/impl/InMemoryCacheService.java
+++ b/src/main/java/com/echobox/cache/impl/InMemoryCacheService.java
@@ -18,10 +18,12 @@
 package com.echobox.cache.impl;
 
 import com.echobox.cache.CacheService;
+import com.echobox.cache.CachedResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
@@ -66,6 +68,15 @@ public class InMemoryCacheService extends CacheService {
     }
     
     return true;
+  }
+  
+  @Override
+  protected Optional<CachedResult<Object>> getRawCachedItemWithTtl(String key) throws Exception {
+    if (cache.get(key) == null) {
+      return Optional.empty();
+    }
+    
+    return Optional.of(new CachedResult<>(cache.get(key), Long.MAX_VALUE));
   }
 
   @Override

--- a/src/main/java/com/echobox/cache/impl/MemcachedCacheService.java
+++ b/src/main/java/com/echobox/cache/impl/MemcachedCacheService.java
@@ -18,6 +18,7 @@
 package com.echobox.cache.impl;
 
 import com.echobox.cache.CacheService;
+import com.echobox.cache.CachedResult;
 import com.echobox.shutdown.ShutdownMonitor;
 import net.spy.memcached.CASResponse;
 import net.spy.memcached.CASValue;
@@ -34,6 +35,7 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -218,6 +220,19 @@ public class MemcachedCacheService extends CacheService {
    */
   public MemcachedClient getCacheClient() {
     return memcachedClient;
+  }
+  
+  /**
+   * Guaranteed to throw an exception and do nothing as Memcached does not support retrieving
+   * with time to live
+   * @throws UnsupportedOperationException always
+   * @deprecated Unsupported operation
+   */
+  @Override
+  @Deprecated
+  protected Optional<CachedResult<Object>> getRawCachedItemWithTtl(String key) throws Exception {
+    throw new UnsupportedOperationException("This functionality is not supported by this "
+        + "implementation");
   }
   
   @Override

--- a/src/main/java/com/echobox/cache/impl/NoOpCacheService.java
+++ b/src/main/java/com/echobox/cache/impl/NoOpCacheService.java
@@ -18,7 +18,9 @@
 package com.echobox.cache.impl;
 
 import com.echobox.cache.CacheService;
+import com.echobox.cache.CachedResult;
 
+import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
@@ -72,6 +74,11 @@ public class NoOpCacheService extends CacheService {
   @Override
   public boolean tryDeleteItemFromCache(String key) {
     return true;
+  }
+  
+  @Override
+  protected Optional<CachedResult<Object>> getRawCachedItemWithTtl(String key) throws Exception {
+    return Optional.empty();
   }
 
   @Override

--- a/src/main/java/com/echobox/cache/impl/RedisCacheServiceBase.java
+++ b/src/main/java/com/echobox/cache/impl/RedisCacheServiceBase.java
@@ -201,7 +201,7 @@ abstract class RedisCacheServiceBase<S> extends CacheService {
           throw new IllegalStateException("Unexpected result type: " + result.getClass());
         }
         List<?> resultList = (List<?>) result;
-        if (resultList.size() < 2) {
+        if (resultList.size() != 2) {
           throw new IllegalStateException("Unexpected result size: " + resultList.size());
         }
         Object value = resultList.get(0);
@@ -209,7 +209,7 @@ abstract class RedisCacheServiceBase<S> extends CacheService {
           return Optional.<CachedResult<Object>>empty();
         }
         
-        Long ttl = ((Number) resultList.get(1)).longValue();
+        long ttl = ((Number) resultList.get(1)).longValue();
         
         return Optional.of(new CachedResult<>(value, ttl));
       }).toCompletableFuture().get(DEFAULT_CACHE_TIMEOUT_SECS, TimeUnit.SECONDS);


### PR DESCRIPTION
### Description of Changes
Added support for retrieving cached items with their time to live

CachedResult class
- Added new wrapper class CachedResult to hold an item from the cache and the time to live 

Changes to CacheService
- Added public methods `tryGetCachedItemFromBytesWithTtl`, `tryGetCachedItemWithTtl`
- These use a new protected abstract method `getRawCachedItemWithTtl`

Changes to RedisCacheServiceBase
- Added implementation of `getRawCachedItemWithTtl` which uses a Lua script to ensure the item and time to live are retrieved atomically

This functionality is quite helpful.
One example use case of being able to retrieve the time to live for a cached item atomically is being able to implement probabilistic early expiration which is a great solution for issues like a [cache stampede](https://en.wikipedia.org/wiki/Cache_stampede).

### Documentation

N/A

### Risks & Impacts
Existing methods are unaffected, however because of the new abstract method in CacheService this change is not backwards compatible

### Testing
- Added unit test
- Manually tested new ttl methods for RedisCacheService against a redis cache and confirmed they work and that the returned ttl is correct

## Final Checklist

Please tick once completed.

- [x] Build passes.
- [x] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [x] Change log has been updated.