### PR TITLE
SL-13793 Bump com.google.code.gson to 2.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ebx-cachebase-sdk Changelog
 
+## 2.0.2 (Mar 31, 2025)
+* Bump com.google.code.gson to `2.10.1` to fix security vulnerability.
+
 ## 2.0.1 (Mar 31, 2025)
 
 * Bump lettuce-core dependency to `6.5.5.RELEASE`.

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>com.echobox</groupId>
   <artifactId>ebx-cachebase-sdk</artifactId>
-  <version>2.0.1</version>
+  <version>2.0.2</version>
   <packaging>jar</packaging>
 
   <properties>
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.2</version>
+      <version>2.10.1</version>
     </dependency>
     <dependency>
       <groupId>org.jmockit</groupId>


### PR DESCRIPTION
### Description of Changes

Bump com.google.code.gson to `2.10.1` to fix security vulnerability raised by dependabot.

### Documentation

- N/A

### Risks & Impacts

- Bump to a later version of `com.google.code.gson` which affects ser/de

### Testing

- Unit tests pass

## Final Checklist

Please tick once completed.

- [ ] Build passes.
- [ ] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [ ] Change log has been updated.